### PR TITLE
Base64 string option

### DIFF
--- a/html-to-pdf.js
+++ b/html-to-pdf.js
@@ -19,7 +19,8 @@ exports.setOutputEncoding = function (enc) {
 
 exports.convertHTMLString = function (html, pdfPath, getBase64, callback) {
     var self = this, uniqueID = UUIDGenerator.v4();
-
+    // If no pdfPath is specified, set it as a uuid. This is for getting only the base64 string
+    // and not caring about the file.
     pdfPath = pdfPath || uniqueID + '.pdf';
 
     fs.writeFile(uniqueID + '.html', html, function (err) {
@@ -60,6 +61,7 @@ var convertBase64 = function (pdfPath, callback) {
 }
 
 exports.convertHTMLFile = function (htmlPath, pdfPath, getBase64, callback) {
+    // Same as convertHTMLString
     pdfPath = pdfPath || UUIDGenerator.v4() + '.pdf';
 
     var args = ['-jar', __dirname + '/PDFRenderer.jar'];

--- a/html-to-pdf.js
+++ b/html-to-pdf.js
@@ -17,17 +17,14 @@ exports.setOutputEncoding = function (enc) {
     outputEncoding = enc;
 }
 
-exports.convertHTMLString = function (html, pdfPath, getBase64, callback) {
+exports.convertHTMLString = function (html, pdfPath, callback) {
     var self = this, uniqueID = UUIDGenerator.v4();
-    // If no pdfPath is specified, set it as a uuid. This is for getting only the base64 string
-    // and not caring about the file.
-    pdfPath = pdfPath || uniqueID + '.pdf';
 
     fs.writeFile(uniqueID + '.html', html, function (err) {
         if (err) {
             callback(err);
         } else {
-            self.convertHTMLFile(uniqueID + '.html', pdfPath, getBase64, function (error, results) {
+            self.convertHTMLFile(uniqueID + '.html', pdfPath, function (error, results) {
                 if (error) {
                     callback(error);
                 } else {
@@ -60,8 +57,11 @@ var convertBase64 = function (pdfPath, callback) {
   })
 }
 
-exports.convertHTMLFile = function (htmlPath, pdfPath, getBase64, callback) {
-    // Same as convertHTMLString
+exports.convertHTMLFile = function (htmlPath, pdfPath, callback) {
+    // If no pdfPath is specified, set it as a uuid. This is for getting only the base64 string
+    // and not caring about the file.
+    var getBase64;
+    if (!pdfPath) getBase64 = true;
     pdfPath = pdfPath || UUIDGenerator.v4() + '.pdf';
 
     var args = ['-jar', __dirname + '/PDFRenderer.jar'];

--- a/html-to-pdf.js
+++ b/html-to-pdf.js
@@ -4,7 +4,6 @@ var child_process = require('child_process'),
     debug = false,
     inputEncoding = null,
     outputEncoding = null;
-    getBase64 = false;
 
 exports.setDebug = function (newDebug) {
     debug = newDebug;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "java-src": "java-src"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tape test/*.js | tap-spec"
   },
   "repository": {
     "type": "git",
@@ -31,5 +31,9 @@
   "homepage": "https://github.com/ChaosEvoker/html-to-pdf",
   "dependencies": {
     "node-uuid": "^1.4.1"
+  },
+  "devDependencies": {
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -7,18 +7,15 @@ var htmlPath = path.join(__dirname, 'test.html');
 // Left debugging logs out as there were annoying warnings with the html file.
 // htmlToPdf.setDebug(true);
 
-test('convertHTMLFile with base64', function (t) {
-  htmlToPdf.setBase64Output(true);
-  // second argument doesn't matter
-  htmlToPdf.convertHTMLFile(htmlPath, null, function (err, result) {
+test('convertHTMLFileToBase64PDF', function (t) {
+  htmlToPdf.convertHTMLFileToBase64PDF(htmlPath, function (err, result) {
     t.equal(result.process_code, 0, 'Exits with code 0');
     t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
     t.end();
   });
 });
 
-test('convertHTMLFile without base64', function (t) {
-  htmlToPdf.setBase64Output(false);
+test('convertHTMLFile', function (t) {
   htmlToPdf.convertHTMLFile(htmlPath, 'output.pdf', function (err, result) {
     t.equal(result.process_code, 0, 'Exits with code 0');
     t.notOk(result.base64, 'No base64 property');
@@ -29,10 +26,9 @@ test('convertHTMLFile without base64', function (t) {
   });
 });
 
-test('convertHTMLString with base64', function (t) {
-  htmlToPdf.setBase64Output(true);
+test('convertHTMLStringToBase64PDF', function (t) {
   fs.readFile(htmlPath, function (err, string) {
-    htmlToPdf.convertHTMLString(string, null, function (err, result) {
+    htmlToPdf.convertHTMLStringToBase64PDF(string, function (err, result) {
       t.equal(result.process_code, 0, 'Exits with code 0');
       t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
       t.end();
@@ -40,8 +36,7 @@ test('convertHTMLString with base64', function (t) {
   });
 });
 
-test('convertHTMLString without base64', function (t) {
-  htmlToPdf.setBase64Output(false);
+test('convertHTMLString', function (t) {
   fs.readFile(htmlPath, function (err, string) {
     htmlToPdf.convertHTMLString(string, 'output.pdf', function (err, result) {
       t.equal(result.process_code, 0, 'Exits with code 0');

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,12 @@
+var test = require('tape');
+var path = require('path');
+var htmlToPdf = require('../html-to-pdf');
+
+test('convertHTMLFile', function (t) {
+  htmlToPdf.setDebug(true);
+  htmlToPdf.convertHTMLFile(path.join(__dirname, 'test.html'), null, true, function (err, result) {
+    t.equal(result. process_code, 0, 'Exits with code 0');
+    t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
+    t.end();
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,24 @@
 var test = require('tape');
 var path = require('path');
+var fs = require('fs');
 var htmlToPdf = require('../html-to-pdf');
 
+htmlToPdf.setDebug(true);
+
 test('convertHTMLFile', function (t) {
-  htmlToPdf.setDebug(true);
   htmlToPdf.convertHTMLFile(path.join(__dirname, 'test.html'), null, true, function (err, result) {
     t.equal(result. process_code, 0, 'Exits with code 0');
     t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
     t.end();
+  });
+});
+
+test('convertHTMLString', function (t) {
+  fs.readFile(path.join(__dirname, 'test.html'), function (err, string) {
+    htmlToPdf.convertHTMLString(string, null, true, function (err, result) {
+      t.equal(result. process_code, 0, 'Exits with code 0');
+      t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
+      t.end();
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -17,8 +17,7 @@ test('convertHTMLFileToBase64PDF', function (t) {
 
 test('convertHTMLFile', function (t) {
   htmlToPdf.convertHTMLFile(htmlPath, 'output.pdf', function (err, result) {
-    t.equal(result.process_code, 0, 'Exits with code 0');
-    t.notOk(result.base64, 'No base64 property');
+    t.deepEqual(result, {process_code: 0}, 'Exits with code 0');
     fs.unlink('output.pdf', function (err) {
       t.notOk(err, 'PDF removed correctly');
       t.end();
@@ -39,8 +38,7 @@ test('convertHTMLStringToBase64PDF', function (t) {
 test('convertHTMLString', function (t) {
   fs.readFile(htmlPath, function (err, string) {
     htmlToPdf.convertHTMLString(string, 'output.pdf', function (err, result) {
-      t.equal(result.process_code, 0, 'Exits with code 0');
-      t.notOk(result.base64, 'No base64 property');
+      t.deepEqual(result, {process_code: 0}, 'Exits with code 0');
       fs.unlink('output.pdf', function (err) {
         t.notOk(err, 'PDF removed correctly');
         t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -3,22 +3,48 @@ var path = require('path');
 var fs = require('fs');
 var htmlToPdf = require('../html-to-pdf');
 
-htmlToPdf.setDebug(true);
+var htmlPath = path.join(__dirname, 'test.html');
+// Left debugging logs out as there were annoying warnings with the html file.
+// htmlToPdf.setDebug(true);
 
-test('convertHTMLFile', function (t) {
-  htmlToPdf.convertHTMLFile(path.join(__dirname, 'test.html'), null, true, function (err, result) {
-    t.equal(result. process_code, 0, 'Exits with code 0');
+test('convertHTMLFile with base64', function (t) {
+  htmlToPdf.convertHTMLFile(htmlPath, null, function (err, result) {
+    t.equal(result.process_code, 0, 'Exits with code 0');
     t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
     t.end();
   });
 });
 
-test('convertHTMLString', function (t) {
-  fs.readFile(path.join(__dirname, 'test.html'), function (err, string) {
-    htmlToPdf.convertHTMLString(string, null, true, function (err, result) {
-      t.equal(result. process_code, 0, 'Exits with code 0');
+test('convertHTMLFile without base64', function (t) {
+  htmlToPdf.convertHTMLFile(htmlPath, 'output.pdf', function (err, result) {
+    t.equal(result.process_code, 0, 'Exits with code 0');
+    t.notOk(result.base64, 'No base64 property');
+    fs.unlink('output.pdf', function (err) {
+      t.notOk(err, 'PDF removed correctly');
+      t.end();
+    });
+  });
+});
+
+test('convertHTMLString with base64', function (t) {
+  fs.readFile(htmlPath, function (err, string) {
+    htmlToPdf.convertHTMLString(string, null, function (err, result) {
+      t.equal(result.process_code, 0, 'Exits with code 0');
       t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
       t.end();
+    });
+  });
+});
+
+test('convertHTMLString without base64', function (t) {
+  fs.readFile(htmlPath, function (err, string) {
+    htmlToPdf.convertHTMLString(string, 'output.pdf', function (err, result) {
+      t.equal(result.process_code, 0, 'Exits with code 0');
+      t.notOk(result.base64, 'No base64 property');
+      fs.unlink('output.pdf', function (err) {
+        t.notOk(err, 'PDF removed correctly');
+        t.end();
+      });
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,8 @@ var htmlPath = path.join(__dirname, 'test.html');
 // htmlToPdf.setDebug(true);
 
 test('convertHTMLFile with base64', function (t) {
+  htmlToPdf.setBase64Output(true);
+  // second argument doesn't matter
   htmlToPdf.convertHTMLFile(htmlPath, null, function (err, result) {
     t.equal(result.process_code, 0, 'Exits with code 0');
     t.ok(typeof result.base64 === 'string', 'Returns a base64 property as a string');
@@ -16,6 +18,7 @@ test('convertHTMLFile with base64', function (t) {
 });
 
 test('convertHTMLFile without base64', function (t) {
+  htmlToPdf.setBase64Output(false);
   htmlToPdf.convertHTMLFile(htmlPath, 'output.pdf', function (err, result) {
     t.equal(result.process_code, 0, 'Exits with code 0');
     t.notOk(result.base64, 'No base64 property');
@@ -27,6 +30,7 @@ test('convertHTMLFile without base64', function (t) {
 });
 
 test('convertHTMLString with base64', function (t) {
+  htmlToPdf.setBase64Output(true);
   fs.readFile(htmlPath, function (err, string) {
     htmlToPdf.convertHTMLString(string, null, function (err, result) {
       t.equal(result.process_code, 0, 'Exits with code 0');
@@ -37,6 +41,7 @@ test('convertHTMLString with base64', function (t) {
 });
 
 test('convertHTMLString without base64', function (t) {
+  htmlToPdf.setBase64Output(false);
   fs.readFile(htmlPath, function (err, string) {
     htmlToPdf.convertHTMLString(string, 'output.pdf', function (err, result) {
       t.equal(result.process_code, 0, 'Exits with code 0');


### PR DESCRIPTION
First of all thanks for this lib, very useful.

My use case: I want to obtain the base64 string from the PDF, I don't care about the file as I'm sending the PDF as an email attachment (and the Sendgrid API only accepts base64 strings). 

I do this in a similar way to how you've done the htmlstring function, by creating a temp PDF file with a uuid, but thought I'd make the changes to the lib itself. 

If you call either of the two convert functions without the `pdfPath` arg, the base64 string will be attached to the `result` object given in the callback, and a temp file will be created and cleaned up.

Example:

``` js
htmlToPdf.convertHTMLFile(htmlPath, null, function (err, result) {
  // result.base64 is the base64 string, no PDF file is created
});
```

Also wrote tests for the functions with tape. 

Using the functions with a `pdfPath` will still work the normal way. It's only when a falsey value is passed that the base64 string will be returned.

One thing I noticed is that the lib is quite slow, not sure if this is due to FlyingSaucer or the file I/O?
